### PR TITLE
more flexible choice for default snippet folder

### DIFF
--- a/BetterSnippetManager.py
+++ b/BetterSnippetManager.py
@@ -59,8 +59,6 @@ class BetterSnippetManagerEditCommand(sublime_plugin.WindowCommand):
         snippets_folder = get_settings().get('snippets_folder')
         extension = get_snippet_extension()
         self.SNIPPETS_PATH = os.path.join(sublime.packages_path(), 'User')
-        if snippets_folder:
-            self.SNIPPETS_PATH = os.path.join(self.SNIPPETS_PATH, snippets_folder)
 
         self.all_snippets = self.__list_all_snippets(self.SNIPPETS_PATH, [], extension)
         if len(self.all_snippets) == 0:
@@ -98,6 +96,28 @@ class BetterSnippetManagerCreateCommand(sublime_plugin.TextCommand):
     def set_scopes(self, scopes):
         self.scopes = self.escape(scopes)
         folder = self.scopes.split(' ')[0].split('.')[-1]
+
+        user_folder = get_settings().get('snippets_folder')
+        use_base_folder = get_settings().get('use_sublime_snippets_folder_as_base_folder')
+
+        # use base folder + custom folder
+        if use_base_folder and user_folder:
+            folder = os.path.join("Snippets", user_folder)
+
+        # use base folder only
+        elif use_base_folder and user_folder is None:
+            folder = "Snippets"
+
+        # use base folder + scope folder
+        elif use_base_folder:
+            folder = os.path.join("Snippets", folder)
+
+        # use custom folder
+        elif user_folder:
+            folder = user_folder
+
+        # otherwise leave folder variable unchanged and use scope folder
+
         view = self.window.show_input_panel('Folder: ', folder, self.set_folder, None, None)
 
     def set_folder(self, folder):
@@ -121,7 +141,6 @@ class BetterSnippetManagerCreateCommand(sublime_plugin.TextCommand):
             template = templates.xml
 
         file_path = os.path.join(sublime.packages_path(), 'User',
-                                 get_settings().get('snippets_folder') or '',
                                  computer_friendly(self.folder), file_name)
 
         if not os.path.exists(os.path.dirname(file_path)):

--- a/BetterSnippetManager.py
+++ b/BetterSnippetManager.py
@@ -97,28 +97,19 @@ class BetterSnippetManagerCreateCommand(sublime_plugin.TextCommand):
 
     def set_scopes(self, scopes):
         self.scopes = self.escape(scopes)
-        folder = self.scopes.split(' ')[0].split('.')[-1]
 
+        scope_folder = self.scopes.split(' ')[0].split('.')[-1]
         user_folder = get_settings().get('snippets_folder')
-        use_base_folder = get_settings().get('use_sublime_snippets_folder_as_base_folder')
+        base_folder = "Snippets" if get_settings(
+            ).get('use_sublime_snippets_folder_as_base_folder') else ""
+
+        # use base folder + user_folder + scope folder
+        if get_settings().get('use_scope_subfolder'):
+            folder = os.path.join(base_folder, user_folder, scope_folder)
 
         # use base folder + custom folder
-        if use_base_folder and user_folder:
-            folder = os.path.join("Snippets", user_folder)
-
-        # use base folder only
-        elif use_base_folder and user_folder is None:
-            folder = "Snippets"
-
-        # use base folder + scope folder
-        elif use_base_folder:
-            folder = os.path.join("Snippets", folder)
-
-        # use custom folder
-        elif user_folder:
-            folder = user_folder
-
-        # otherwise leave folder variable unchanged and use scope folder
+        else:
+            folder = os.path.join(base_folder, user_folder)
 
         view = self.window.show_input_panel('Folder: ', folder, self.set_folder, None, None)
 

--- a/BetterSnippetManager.py
+++ b/BetterSnippetManager.py
@@ -59,6 +59,8 @@ class BetterSnippetManagerEditCommand(sublime_plugin.WindowCommand):
         snippets_folder = get_settings().get('snippets_folder')
         extension = get_snippet_extension()
         self.SNIPPETS_PATH = os.path.join(sublime.packages_path(), 'User')
+        if get_settings().get('use_sublime_snippets_folder_as_base_folder'):
+            self.SNIPPETS_PATH = os.path.join(self.SNIPPETS_PATH, "Snippets")
 
         self.all_snippets = self.__list_all_snippets(self.SNIPPETS_PATH, [], extension)
         if len(self.all_snippets) == 0:

--- a/BetterSnippetManager.py
+++ b/BetterSnippetManager.py
@@ -107,6 +107,10 @@ class BetterSnippetManagerCreateCommand(sublime_plugin.TextCommand):
         if get_settings().get('use_scope_subfolder'):
             folder = os.path.join(base_folder, user_folder, scope_folder)
 
+        # use base folder only
+        elif not user_folder:
+            folder = base_folder
+
         # use base folder + custom folder
         else:
             folder = os.path.join(base_folder, user_folder)

--- a/BetterSnippetManager.sublime-settings
+++ b/BetterSnippetManager.sublime-settings
@@ -1,10 +1,11 @@
 {
-    // set to true to use User\Snippets folder as base folder for newly created snippets
+    // set to true to use User/Snippets folder as base folder for newly created snippets
 
     "use_sublime_snippets_folder_as_base_folder": true,
 
-    // default snippet folder, if left empty the name will be generated from current scope
-    // set to 'null' and above to 'true' to use the default folder (User/Snippets)
+    // default snippet subfolder, if left empty the name will be generated from
+    // current scope; set to 'null' and above to 'true' to use the default
+    // folder (User/Snippets) without scope subfolder
 
     "snippets_folder": "",
 

--- a/BetterSnippetManager.sublime-settings
+++ b/BetterSnippetManager.sublime-settings
@@ -1,9 +1,15 @@
 {
-    // which folder you want to store all your snippets in
-    // it can be set to null
-    "snippets_folder": "snippets",
+    // set to true to use User\Snippets folder as base folder for newly created snippets
+
+    "use_sublime_snippets_folder_as_base_folder": true,
+
+    // default snippet folder, if left empty the name will be generated from current scope
+    // set to 'null' and above to 'true' to use the default folder (User/Snippets)
+
+    "snippets_folder": "",
 
     // SaneSnippet is a package which allows you to write your snippet
     // with a yaml front matter. Check it out!
+
     "use_sane_snippets": false
 }

--- a/BetterSnippetManager.sublime-settings
+++ b/BetterSnippetManager.sublime-settings
@@ -1,13 +1,12 @@
 {
-    // set to true to use User/Snippets folder as base folder for newly created snippets
-
+    // use User/Snippets folder as base folder for newly created snippets
     "use_sublime_snippets_folder_as_base_folder": true,
 
-    // default snippet subfolder, if left empty the name will be generated from
-    // current scope; set to 'null' and above to 'true' to use the default
-    // folder (User/Snippets) without scope subfolder
-
+    // default snippet subfolder
     "snippets_folder": "",
+
+    // add a subfolder generated from scope name at snippet creation
+    "use_scope_subfolder": true,
 
     // SaneSnippet is a package which allows you to write your snippet
     // with a yaml front matter. Check it out!


### PR DESCRIPTION
fix for 'edit snippet' command when 'snippets_folder' setting is set to a value
so that you can edit all snippets found in User folder (and subdirs)